### PR TITLE
Cobble boot config

### DIFF
--- a/boot/__init__.py
+++ b/boot/__init__.py
@@ -20,6 +20,7 @@ from flask_sslify import SSLify
 from .stage1 import init_app as init_stage1
 from .stage2 import init_app as init_stage2
 from .auth import rebble, init_app as init_auth
+from .cobble import init_app as init_cobble
 from .settings import config
 
 app = Flask(__name__)
@@ -34,6 +35,7 @@ if not app.debug:
 init_stage1(app)
 init_stage2(app)
 init_auth(app)
+init_cobble(app)
 
 # XXX: upstream this
 import beeline

--- a/boot/cobble.py
+++ b/boot/cobble.py
@@ -1,0 +1,33 @@
+from flask import Blueprint, jsonify, request
+import requests
+
+from .settings import config
+
+cobble = Blueprint('cobble', __name__)
+
+@cobble.route('/')
+def boot_cobble():
+    build = request.args.get('build')
+    platform = request.args.get('platform')
+    locale = request.args.get('locale', 'en_US')
+    boot = {
+        "auth": {
+            "base": f"{config['REBBLE_AUTH_URL']}/api",
+            "authorise_url": f"{config['REBBLE_AUTH_URL']}/oauth/authorise",
+            "refresh_url": f"{config['REBBLE_AUTH_URL']}/oauth/token",
+            "client_id": config['COBBLE_OAUTH_CLIENT_ID']
+        },
+        "appstore": {
+            "base": f"{config['APPSTORE_API_URL']}/api"
+        },
+        "webviews": {
+            "appstoreApplication": f"{config['APPSTORE_URL']}/{locale}/application/",
+            "appstoreWatchapps": f"{config['APPSTORE_URL']}/{locale}/watchapps",
+            "appstoreWatchfaces": f"{config['APPSTORE_URL']}/{locale}/watchfaces",
+            "manageAccount": config['REBBLE_ACCOUNT_URL']
+        }
+    }
+    return jsonify(boot)
+
+def init_app(app, prefix='/api/cobble'):
+    app.register_blueprint(cobble, url_prefix=prefix)

--- a/boot/cobble.py
+++ b/boot/cobble.py
@@ -13,7 +13,7 @@ def boot_cobble():
     boot = {
         "auth": {
             "base": f"{config['REBBLE_AUTH_URL']}/api",
-            "authorise_url": f"{config['REBBLE_AUTH_URL']}/oauth/authorise",
+            "authorize_url": f"{config['REBBLE_AUTH_URL']}/oauth/authorise",
             "refresh_url": f"{config['REBBLE_AUTH_URL']}/oauth/token",
             "client_id": config['COBBLE_OAUTH_CLIENT_ID']
         },

--- a/boot/settings.py
+++ b/boot/settings.py
@@ -23,4 +23,6 @@ config = {
     },
     'HONEYCOMB_KEY': environ.get('HONEYCOMB_KEY', None),
     'WS_PROXY_URL': environ.get('WS_PROXY_URL', f'ws://dev-ws-proxy.{domain_root}'),
+    'COBBLE_OAUTH_CLIENT_ID': environ['COBBLE_OAUTH_CLIENT_ID'],
+    'REBBLE_ACCOUNT_URL': environ.get('REBBLE_ACCOUNT_URL', f"{http_protocol}://auth.{domain_root}/account/"),
 }


### PR DESCRIPTION
Adds boot config for cobble, which currently only includes:
 - Auth
 - Appstore
 - Assorted webviews/links

Environment variables:
 - `COBBLE_OAUTH_CLIENT_ID` - OAuth client ID / consumer key for cobble app, requires redirect uri `rebble://auth_complete`
 - `REBBLE_ACCOUNT_URL` - Link to rebble account settings, opened from cobble