### PR TITLE
Add optional override force_ua

### DIFF
--- a/boot/__init__.py
+++ b/boot/__init__.py
@@ -54,8 +54,8 @@ def index():
 
     platform = request.user_agent.platform
 
-    is_ios = platform in ('iphone', 'ipad')
-    is_android = (platform == 'android' or 'BB10' in request.user_agent.string)  # BB10 runs Pebble Android.
+    is_ios = (platform in ('iphone', 'ipad') or request.args.get('force_ua') == "ios")
+    is_android = (platform == 'android' or 'BB10' in request.user_agent.string or request.args.get('force_ua') == "android")  # BB10 runs Pebble Android.
     os_path = ''
     if is_ios:
         os = 'ios'


### PR DESCRIPTION
Allows users on Ipads or other devices that are not being detected as mobiles to visit

https://boot.rebble.io/?force_ua=ios or https://boot.rebble.io/?force_ua=android to force the 'boot' button to appear and kick off boot for that UA.

My boot/auth env. is playing up so this isn't fully tested, but I tested in a simple flask app and it appears to work fine